### PR TITLE
Add AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,8 @@
+image: Visual Studio 2017
+configuration:
+  - Release
+  - Debug
+platform:
+  - x86
+build:
+  project: Outpost2DLL.sln

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,5 @@ image: Visual Studio 2017
 configuration:
   - Release
   - Debug
-platform:
-  - x86
 build:
   project: Outpost2DLL.sln

--- a/Outpost2DLL.cpp
+++ b/Outpost2DLL.cpp
@@ -1,0 +1,4 @@
+// This is a dummy source file for what is effectively a header only library.
+// Adding it to the project allows the project to build, which runs all
+// included headers through the compiler, checking for syntax errors.
+#include "Outpost2DLL.h"

--- a/Outpost2DLL.vcxproj
+++ b/Outpost2DLL.vcxproj
@@ -11,6 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Outpost2DLL.cpp" />
     <ClInclude Include="Enumerators.h" />
     <ClInclude Include="Enums.h" />
     <ClInclude Include="GameMap.h" />

--- a/Outpost2DLL.vcxproj.filters
+++ b/Outpost2DLL.vcxproj.filters
@@ -62,6 +62,11 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Outpost2DLL.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
     <Library Include="Lib\Outpost2DLL.lib">
       <Filter>Lib</Filter>
     </Library>


### PR DESCRIPTION
Adding AppVeyor automated builds.

I noticed the platform configuration for this project is different from other projects. Namely, using "x86" doesn't work. I noticed "Win32" is used as the platform in the project file. I'm wondering if the different is an artifact of upgrading an old project versus creating a new project file. At any rate, removing the platform specification from the `.appveyor.yml` file allows the defaults to build the project.

Looking at the build logs, it doesn't look like it actually builds anything. I think this is because we have no source files in this project. It is header file only. Maybe we should add a dummy `Outpost2DLL.cpp` file, which includes the main `Outpost2DLL.h` file. That should get it running all the header code through the compiler, and verifying there are no syntax errors.
