### PR TITLE
Add const to data exports

### DIFF
--- a/RequiredExports.h
+++ b/RequiredExports.h
@@ -33,24 +33,33 @@ struct AIModDesc
 	int maxTechLevel;			// Maximum tech level (Set to 12 to enable all techs)
 	int boolUnitMission;		// Set to 1 to disable most reports (suitable for unit-only missions)
 	// Extra baggage that doesn't need to be set properly
-	char* mapName;
-	char* levelDesc;
-	char* techtreeName;
+	const char* mapName;
+	const char* levelDesc;
+	const char* techtreeName;
 	int checksum;
 };
 
+// Helper macro to declare level DLL required data exports
+#define DeclareExportedLevelDetails \
+	Export const char MapName[]; \
+	Export const char LevelDesc[]; \
+	Export const char TechtreeName[]; \
+	Export const AIModDesc DescBlock;
+
 // Helper Macros to define the required data exports
 #define ExportLevelDetails(levelDesc, mapName, techTreeName, missionType, numPlayers) \
-	Export char MapName[] = mapName; \
-	Export char LevelDesc[] = levelDesc; \
-	Export char TechtreeName[] = techTreeName; \
-	Export AIModDesc DescBlock = { missionType, numPlayers, (missionType > 0) ? missionType : 12, false, MapName, LevelDesc, TechtreeName, 0 }; \
+	DeclareExportedLevelDetails \
+	Export const char MapName[] = mapName; \
+	Export const char LevelDesc[] = levelDesc; \
+	Export const char TechtreeName[] = techTreeName; \
+	Export const AIModDesc DescBlock = { missionType, numPlayers, (missionType > 0) ? missionType : 12, false, MapName, LevelDesc, TechtreeName, 0 }; \
 
 #define ExportLevelDetailsEx(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission) \
-	Export char MapName[] = mapName; \
-	Export char LevelDesc[] = levelDesc; \
-	Export char TechtreeName[] = techTreeName; \
-	Export AIModDesc DescBlock = { missionType, numPlayers, maxTechLevel, bUnitOnlyMission, MapName, LevelDesc, TechtreeName, 0 };
+	DeclareExportedLevelDetails \
+	Export const char MapName[] = mapName; \
+	Export const char LevelDesc[] = levelDesc; \
+	Export const char TechtreeName[] = techTreeName; \
+	Export const AIModDesc DescBlock = { missionType, numPlayers, maxTechLevel, bUnitOnlyMission, MapName, LevelDesc, TechtreeName, 0 };
 
 // This struct defined a memory region to be Saved/Loaded to/from saved game files.
 // Note: See GetSaveRegions exported function

--- a/RequiredExports.h
+++ b/RequiredExports.h
@@ -39,23 +39,14 @@ struct AIModDesc
 	int checksum;
 };
 
-// Helper macro to declare level DLL required data exports
-#define DeclareExportedLevelDetails \
-	Export const char MapName[]; \
-	Export const char LevelDesc[]; \
-	Export const char TechtreeName[]; \
-	Export const AIModDesc DescBlock;
-
 // Helper Macros to define the required data exports
 #define ExportLevelDetails(levelDesc, mapName, techTreeName, missionType, numPlayers) \
-	DeclareExportedLevelDetails \
 	Export const char MapName[] = mapName; \
 	Export const char LevelDesc[] = levelDesc; \
 	Export const char TechtreeName[] = techTreeName; \
 	Export const AIModDesc DescBlock = { missionType, numPlayers, (missionType > 0) ? missionType : 12, false, MapName, LevelDesc, TechtreeName, 0 }; \
 
 #define ExportLevelDetailsEx(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission) \
-	DeclareExportedLevelDetails \
 	Export const char MapName[] = mapName; \
 	Export const char LevelDesc[] = levelDesc; \
 	Export const char TechtreeName[] = techTreeName; \

--- a/RequiredExports.h
+++ b/RequiredExports.h
@@ -101,10 +101,10 @@ typedef AIModDesc SDescBlock;
 //		 used, and what description to place in the level list box. A
 //		 structure is also exported to give additional mission info
 //		 (some of which corresponds to the naming of the DLL).
-Export char MapName[];			// Holds the file name of the .map file
-Export char LevelDesc[];		// Description that appears in the list/menu
-Export char TechtreeName[];		// The tech tree to use for this level
-Export AIModDesc DescBlock;		// Exports game info
+Export const char MapName[];      // Holds the file name of the .map file
+Export const char LevelDesc[];    // Description that appears in the list/menu
+Export const char TechtreeName[]; // The tech tree to use for this level
+Export const AIModDesc DescBlock; // Exports game info
 
 
 // Note: These functions are required exports from all level DLLs.


### PR DESCRIPTION
This should allow for easier initialization with string literals. It's also perhaps a little more correct, as this data is not expected to change at runtime.

----

I believe the `DeclareExportedLevelDetails` macros was added to prevents warnings from both declaring and initializing an export at the same time.
