### PR TITLE
Update export level details

### DIFF
--- a/RequiredExports.h
+++ b/RequiredExports.h
@@ -40,14 +40,18 @@ struct AIModDesc
 };
 
 // Helper Macros to define the required data exports
-#define ExportLevelDetailsEx(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission) \
+#define ExportLevelDetailsFull(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission) \
 	Export const char MapName[] = mapName; \
 	Export const char LevelDesc[] = levelDesc; \
 	Export const char TechtreeName[] = techTreeName; \
 	Export const AIModDesc DescBlock = { missionType, numPlayers, maxTechLevel, bUnitOnlyMission, MapName, LevelDesc, TechtreeName, 0 };
 
 #define ExportLevelDetails(levelDesc, mapName, techTreeName, missionType, numPlayers) \
-	ExportLevelDetailsEx(levelDesc, mapName, techTreeName, missionType, numPlayers, (missionType > 0) ? missionType : 12, false)
+	ExportLevelDetailsFull(levelDesc, mapName, techTreeName, missionType, numPlayers, (missionType > 0) ? missionType : 12, false)
+
+#define ExportLevelDetailsEx(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission) \
+	_Pragma("message(\"Warning: `ExportLevelDetailsEx` has been deprecated. Please use `ExportLevelDetailsFull` instead\")") \
+	ExportLevelDetailsFull(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission)
 
 // Struct introduced in the official Sierra release update pack 1 (1.2.0.7)
 // Set aiPlayerCount to 1 to allow a computer controlled AI in a multiplayer scenario

--- a/RequiredExports.h
+++ b/RequiredExports.h
@@ -70,7 +70,7 @@ struct AIModDescEx {
 // The name is potentially confusing as it did not create a `DescBlockEx` export
 // May be replaced by an incompatible macro in future versions of the SDK
 #define ExportLevelDetailsEx(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission) \
-	_Pragma("message(\"Warning: `ExportLevelDetailsEx` has been deprecated. Please use `ExportLevelDetailsFull` instead\")") \
+	__pragma(message("Warning: `ExportLevelDetailsEx` has been deprecated. Please use `ExportLevelDetailsFull` instead")) \
 	ExportLevelDetailsFull(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission)
 
 // Full level details for Outpost 2 version 1.2.0.7 and up

--- a/RequiredExports.h
+++ b/RequiredExports.h
@@ -39,6 +39,14 @@ struct AIModDesc
 	int checksum;
 };
 
+// Struct introduced in the official Sierra release update pack 1 (1.2.0.7)
+// Set aiPlayerCount to 1 to allow a computer controlled AI in a multiplayer scenario
+// Example: Export AIModDescEx aiModDescEx = { 1 };
+struct AIModDescEx {
+	int aiPlayerCount;
+	int unused[7];
+};
+
 // Helper Macros to define the required data exports
 
 // Full level details for Outpost 2 version 1.2.0.5 and up
@@ -69,13 +77,6 @@ struct AIModDesc
 	ExportLevelDetailsFull(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission) \
 	Export const AIModDescEx DescBlockEx = { numAiPlayers };
 
-// Struct introduced in the official Sierra release update pack 1 (1.2.0.7)
-// Set aiPlayerCount to 1 to allow a computer controlled AI in a multiplayer scenario
-// Example: Export AIModDescEx aiModDescEx = { 1 };
-struct AIModDescEx {
-	int aiPlayerCount;
-	int unused[7];
-};
 
 // This struct defined a memory region to be Saved/Loaded to/from saved game files.
 // Note: See GetSaveRegions exported function

--- a/RequiredExports.h
+++ b/RequiredExports.h
@@ -53,6 +53,10 @@ struct AIModDesc
 	_Pragma("message(\"Warning: `ExportLevelDetailsEx` has been deprecated. Please use `ExportLevelDetailsFull` instead\")") \
 	ExportLevelDetailsFull(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission)
 
+#define ExportLevelDetailsFullEx(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission, numAiPlayers) \
+	ExportLevelDetailsFull(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission) \
+	Export const AIModDescEx DescBlockEx = { numAiPlayers };
+
 // Struct introduced in the official Sierra release update pack 1 (1.2.0.7)
 // Set aiPlayerCount to 1 to allow a computer controlled AI in a multiplayer scenario
 // Example: Export AIModDescEx aiModDescEx = { 1 };

--- a/RequiredExports.h
+++ b/RequiredExports.h
@@ -40,17 +40,17 @@ struct AIModDesc
 };
 
 // Helper Macros to define the required data exports
-#define ExportLevelDetails(levelDesc, mapName, techTreeName, missionType, numPlayers) \
-	Export const char MapName[] = mapName; \
-	Export const char LevelDesc[] = levelDesc; \
-	Export const char TechtreeName[] = techTreeName; \
-	Export const AIModDesc DescBlock = { missionType, numPlayers, (missionType > 0) ? missionType : 12, false, MapName, LevelDesc, TechtreeName, 0 }; \
-
 #define ExportLevelDetailsEx(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission) \
 	Export const char MapName[] = mapName; \
 	Export const char LevelDesc[] = levelDesc; \
 	Export const char TechtreeName[] = techTreeName; \
 	Export const AIModDesc DescBlock = { missionType, numPlayers, maxTechLevel, bUnitOnlyMission, MapName, LevelDesc, TechtreeName, 0 };
+
+#define ExportLevelDetails(levelDesc, mapName, techTreeName, missionType, numPlayers) \
+	Export const char MapName[] = mapName; \
+	Export const char LevelDesc[] = levelDesc; \
+	Export const char TechtreeName[] = techTreeName; \
+	Export const AIModDesc DescBlock = { missionType, numPlayers, (missionType > 0) ? missionType : 12, false, MapName, LevelDesc, TechtreeName, 0 }; \
 
 // Struct introduced in the official Sierra release update pack 1 (1.2.0.7)
 // Set aiPlayerCount to 1 to allow a computer controlled AI in a multiplayer scenario

--- a/RequiredExports.h
+++ b/RequiredExports.h
@@ -40,19 +40,31 @@ struct AIModDesc
 };
 
 // Helper Macros to define the required data exports
+
+// Full level details for Outpost 2 version 1.2.0.5 and up
+// Needed for unit only missions, or non-standard tech level settings
+// Does not support multiplayer AI (added in Outpost 2 versions 1.2.0.7)
 #define ExportLevelDetailsFull(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission) \
 	Export const char MapName[] = mapName; \
 	Export const char LevelDesc[] = levelDesc; \
 	Export const char TechtreeName[] = techTreeName; \
 	Export const AIModDesc DescBlock = { missionType, numPlayers, maxTechLevel, bUnitOnlyMission, MapName, LevelDesc, TechtreeName, 0 };
 
+// Simplified level details for Outpost 2 version 1.2.0.5 and up
+// Suitable for most levels (colony, campaign, multiplayer), except unit only missions
 #define ExportLevelDetails(levelDesc, mapName, techTreeName, missionType, numPlayers) \
 	ExportLevelDetailsFull(levelDesc, mapName, techTreeName, missionType, numPlayers, (missionType > 0) ? missionType : 12, false)
 
+// Deprecated macro. Renamed to ExportLevelDetailsFull
+// The name is potentially confusing as it did not create a `DescBlockEx` export
+// May be replaced by an incompatible macro in future versions of the SDK
 #define ExportLevelDetailsEx(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission) \
 	_Pragma("message(\"Warning: `ExportLevelDetailsEx` has been deprecated. Please use `ExportLevelDetailsFull` instead\")") \
 	ExportLevelDetailsFull(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission)
 
+// Full level details for Outpost 2 version 1.2.0.7 and up
+// Needed for multiplayer AI support
+// Supports all level configurations, including multiplayer AI
 #define ExportLevelDetailsFullEx(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission, numAiPlayers) \
 	ExportLevelDetailsFull(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission) \
 	Export const AIModDescEx DescBlockEx = { numAiPlayers };

--- a/RequiredExports.h
+++ b/RequiredExports.h
@@ -47,10 +47,7 @@ struct AIModDesc
 	Export const AIModDesc DescBlock = { missionType, numPlayers, maxTechLevel, bUnitOnlyMission, MapName, LevelDesc, TechtreeName, 0 };
 
 #define ExportLevelDetails(levelDesc, mapName, techTreeName, missionType, numPlayers) \
-	Export const char MapName[] = mapName; \
-	Export const char LevelDesc[] = levelDesc; \
-	Export const char TechtreeName[] = techTreeName; \
-	Export const AIModDesc DescBlock = { missionType, numPlayers, (missionType > 0) ? missionType : 12, false, MapName, LevelDesc, TechtreeName, 0 }; \
+	ExportLevelDetailsEx(levelDesc, mapName, techTreeName, missionType, numPlayers, (missionType > 0) ? missionType : 12, false)
 
 // Struct introduced in the official Sierra release update pack 1 (1.2.0.7)
 // Set aiPlayerCount to 1 to allow a computer controlled AI in a multiplayer scenario

--- a/RequiredExports.h
+++ b/RequiredExports.h
@@ -4,8 +4,10 @@
 //		 DLL that are needed in order for Outpost 2 to recognize the DLL
 //		 as a level.
 
+
 // A define used to make exporting functions and variables easier
 #define Export extern "C" __declspec(dllexport)
+
 
 // Mission types, and the corresponding DLL name prefix
 // Note: For campaign games, use a positive level number, and a prefix of e (Eden) or p (Plymouth)
@@ -46,6 +48,7 @@ struct AIModDescEx {
 	int aiPlayerCount;
 	int unused[7];
 };
+
 
 // Helper Macros to define the required data exports
 


### PR DESCRIPTION
Ok, I think this strikes a reasonable compromise. Closes #7.

Old code will still work, with a compile time message warning if they use `ExportLevelDetailsEx`.

A renamed `ExportLevelDetailsFull` macro has been provided to replace it. An expanded `ExportLevelDetailsFullEx` was added to include support for the `DescBlockEx` export.

----

In the future, we may consider updating the old `ExportLevelDetailsEx`, and undeprecating it. To make the API more consistent, it could be changed into a Simplified + DescBlockEx macro. That would require adjusting the parameters and making  it export a `DescBlockEx` struct. Existing code that hasn't been updated would then get a hard error at that time, due to the change in the number of parameters.

The future change might be renaming:
```cpp
#define ExportLevelDetailsEx(levelDesc, mapName, techTreeName, missionType, numPlayers, maxTechLevel, bUnitOnlyMission)  // Old (Full DescBlock)
#define ExportLevelDetailsEx(levelDesc, mapName, techTreeName, missionType, numPlayers, numAiPlayers)  // Future (Simplified DescBlock + DescBlockEx)
```
