### PR TITLE
Convert `enum` forward declares to header includes

### DIFF
--- a/game/Enumerators.h
+++ b/game/Enumerators.h
@@ -8,8 +8,9 @@
 //		 or traverse a list of units one unit at a time.
 
 
+#include "MapIdEnum.h"
+
 // External type names
-enum map_id;
 struct LOCATION;
 struct MAP_RECT;
 class ScGroup;

--- a/game/Groups.h
+++ b/game/Groups.h
@@ -10,11 +10,11 @@
 
 
 #include "ScStub.h"
+#include "MapIdEnum.h"
+#include "Enums.h"
 
 
 // External type names
-enum map_id;
-enum UnitClassifactions;	// ** Typo **
 struct LOCATION;
 struct MAP_RECT;
 struct MrRec;

--- a/game/Player.h
+++ b/game/Player.h
@@ -17,8 +17,9 @@
 //		 hardcoded into each DLL).
 
 
+#include "MapIdEnum.h"
+
 // External type names
-enum map_id;
 struct MAP_RECT;
 class ScGroup;		// **
 

--- a/game/Player.h
+++ b/game/Player.h
@@ -18,6 +18,7 @@
 
 
 #include "MapIdEnum.h"
+#include "Enums.h"
 
 // External type names
 struct MAP_RECT;

--- a/game/Structs.h
+++ b/game/Structs.h
@@ -4,15 +4,13 @@
 #endif
 
 
-// External type names
-enum map_id;
-enum UnitClassifactions;
-
-
 // Note: This file contains all the exported structures from Outpost2.exe.
 // Note: Some of these structures are really more like full classes but
 //		 since they called them struct's we'll let that one slide. =)
 
+
+#include "MapIdEnum.h"
+#include "Enums.h"
 
 
 // Note: These first two structs have all member functions defined and

--- a/game/TethysGame.h
+++ b/game/TethysGame.h
@@ -6,9 +6,10 @@
 // Note: This file contains the defintion of the TethysGame class
 //		which controls the overall game environment
 
+#include "MapIdEnum.h"
+#include "Enums.h"
+
 // External type names
-enum map_id;
-enum SongIds;
 struct LOCATION;
 class Unit;
 class _Player;

--- a/game/Trigger.h
+++ b/game/Trigger.h
@@ -4,11 +4,10 @@
 #endif
 
 #include "ScStub.h"
+#include "MapIdEnum.h"
+#include "Enums.h"
 
 // External type names
-enum map_id;
-enum compare_mode;
-enum trig_res;
 class Unit;
 class ScGroup;
 

--- a/game/Unit.h
+++ b/game/Unit.h
@@ -9,9 +9,10 @@
 //		 classes used to find units and traverse lists of units, one unit
 //		 at a time. See Enumerator.h for details.
 
+#include "MapIdEnum.h"
+#include "Enums.h"
+
 // External type names
-enum map_id;
-enum Truck_Cargo;
 struct LOCATION;
 struct CommandPacket;
 


### PR DESCRIPTION
Forward declaring enums is not technically allowed by the C++ standard. We would need to have `enum class`, or at least an `enum` with a base type specific to allow a forward declare.

If client code is expect to use specific `enum` values, then it would be better to just include the full definition.