### PR TITLE
Add `OP2` export macro to shell header files

### DIFF
--- a/shell/CConfig.h
+++ b/shell/CConfig.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef OP2
+#define OP2 __declspec(dllimport)
+#endif
 
 // OP2 INI config class.
 class OP2 CConfig

--- a/shell/Filters.h
+++ b/shell/Filters.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef OP2
+#define OP2 __declspec(dllimport)
+#endif
 
 class IWnd;
 struct FilterNode;

--- a/shell/IDlgWnd.h
+++ b/shell/IDlgWnd.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef OP2
+#define OP2 __declspec(dllimport)
+#endif
 
 #include "IWnd.h"
 

--- a/shell/IWnd.h
+++ b/shell/IWnd.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef OP2
+#define OP2 __declspec(dllimport)
+#endif
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/shell/ModuleDesc.h
+++ b/shell/ModuleDesc.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef OP2
+#define OP2 __declspec(dllimport)
+#endif
 
 // Outpost2 uses an AIModDesc structure to store and pass information about a mission DLL.
 // See RequiredExports.h for the full definition of AIModDesc.

--- a/shell/ResManager.h
+++ b/shell/ResManager.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef OP2
+#define OP2 __declspec(dllimport)
+#endif
 
 // Outpost2 uses the ResManager to locate and load game resources.
 // It also includes functions to check for the existence of the CD.

--- a/shell/TApp.h
+++ b/shell/TApp.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef OP2
+#define OP2 __declspec(dllimport)
+#endif
 
 
 enum GameTermReasons {

--- a/shell/TFrame.h
+++ b/shell/TFrame.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef OP2
+#define OP2 __declspec(dllimport)
+#endif
 
 #include "IWnd.h"
 

--- a/shell/UIState.h
+++ b/shell/UIState.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef OP2
+#define OP2 __declspec(dllimport)
+#endif
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>


### PR DESCRIPTION
This makes the header files more standalone. It also makes them more consistent with the game header files.