### PR TITLE
Deprecate constant AllPlayers

### DIFF
--- a/Outpost2DLL.vcxproj
+++ b/Outpost2DLL.vcxproj
@@ -80,6 +80,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp14</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -95,6 +96,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp14</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/game/NonExportedEnums.h
+++ b/game/NonExportedEnums.h
@@ -10,7 +10,7 @@
 
 
 
-[[deprecated("AllPlayers will be removed in a future release of Outpost2DLL, Use enum PlayerNum::PlayerALL instead")]]
+[[deprecated("AllPlayers will be removed in a future release of Outpost2DLL, Use enum PlayerNum::PlayerAll instead")]]
 const int AllPlayers = -1;
 
 enum PlayerNum

--- a/game/NonExportedEnums.h
+++ b/game/NonExportedEnums.h
@@ -10,7 +10,7 @@
 
 
 
-
+[[deprecated("AllPlayers will be removed in a future release of Outpost2DLL, Use enum PlayerNum::PlayerALL instead")]]
 const int AllPlayers = -1;
 
 enum PlayerNum


### PR DESCRIPTION
Use enum instead

Updated VS build to be C++14 to allow use of deprecated enum (It will compile without setting to C++14 with MSVC. I suspect the attribute is available in Visual Studio before C++14 standard was implemented but thought it better to be explicit)

Closes #20