### PR TITLE
Remove unnecessary keyword in IDlgWnd

### DIFF
--- a/shell/IDlgWnd.h
+++ b/shell/IDlgWnd.h
@@ -20,13 +20,13 @@ public:
 	virtual int DoModeless(char const *, HINSTANCE, HWND);
 	static HWND __fastcall GetModalParent();
 	int IsModalParentSet() const ;
-	static int __fastcall PretranslateModeless(struct tagMSG *);
+	static int __fastcall PretranslateModeless(tagMSG *);
 	void SetAsModalParent(int);
 
 private:
 	void InsertHWNDChain();
 	void RemoveHWNDChain();
-	static int __stdcall _DlgProc(HWND,unsigned int, unsigned int, long);
+	static int __stdcall _DlgProc(HWND, unsigned int, unsigned int, long);
 	static int nModelessCount;
 	static IDlgWnd *pFirst;
 };


### PR DESCRIPTION
Works on #23 

Regarding: 

```shell/TApp.h:58:	struct IDirectDraw * GetDirectDraw(void) const;```

If I remove the struct keyword from IDirectDraw, I receive the following error on MSVC:

Error (active)	E0020	identifier "IDirectDraw" is undefined	Outpost2DLL	\Outpost2DLL\shell\TApp.h	58

I don't think IDirectDraw is actually defined in the codebase. Not sure if that matters?