### PR TITLE
Remove a specific Windows version target from project settings

### DIFF
--- a/Outpost2DLL.vcxproj
+++ b/Outpost2DLL.vcxproj
@@ -46,7 +46,6 @@
     <ProjectGuid>{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Outpost2DLL</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
My understanding is if this setting is not present in a library project, it will default to using the consuming project's setting on compilation. IE the LevelTemplate project would determine the SDK version if this is not set by Outpost2DLL. I was not specifically targeting a version of Windows when updating project settings in the past to VS2017, although VS2017 seemed to default to the version of Windows 10 that was committed to the repo.

Recently when helping someone else get setup for level development on VS2019, MSVC threw errors because they did not have the SDK associated with the current Windows version target in Outpost2DLL, HFL, and OP2Helper. By removing the setting altogether from all the library projects (HFL, OP2Helper, Outpost2DLL), they were able to just change the LevelTemplate target and compile. Otherwise, they would have to change each library project setting or download a specific SDK. Downloading an SDK takes about a gigabyte of memory. 

This setting seems independent from the Visual Studio Toolset. Admittedly I'm not really smart about the Windows Target Version and in the past focused on the Toolset.

I'd like to update most of the library projects and in this same manner unless someone has different reasoning.