### PR TITLE
Document functionality of MAP_RECT::Inflate

### DIFF
--- a/game/Structs.h
+++ b/game/Structs.h
@@ -45,6 +45,10 @@ public:
 	void ClipToMap();
 	void FromPtSize(const LOCATION&, const LOCATION&);
 	int Height() const;
+	// Use positive values to grow the rectangle and negative values to shrink the rectangle
+	// Automatically wraps coordinates if needed for around the world maps
+	//     unitsWide: X1 decreases by value and X2 increases by value
+	//     unitsHigh: Y1 decreases by value and Y2 increases by value
 	void Inflate(int unitsWide, int unitsHigh);
 	void Offset(int shiftRight, int shiftDown);
 	LOCATION RandPt() const;


### PR DESCRIPTION
Did not check if TethysAPI MapRect acts in the same way

Behaviour seems to be opposite of what I would expect from Inflate, requiring a negative values to increase the area of MAP_RECT